### PR TITLE
[Feature] Automatic Invitation Acceptance For Existing Users

### DIFF
--- a/app/Services/Workspaces/SendInvitation.php
+++ b/app/Services/Workspaces/SendInvitation.php
@@ -24,6 +24,16 @@ class SendInvitation
 
         $invitation = $this->createInvitation($workspace, $email, Workspace::ROLE_MEMBER, $existingUser);
 
+        if ($existingUser) {
+            // If there is an existing user, we are just going to automatically accept the invitation. This avoids
+            // needing to support displaying workspace invitation management to users who are not part of any existing
+            // workspace, but also just makes sense, as it isn't likely that anyone already signed up to a SendPortal
+            // instance would really want to reject an invitation in the first place, so we remove friction here.
+            /** @var AcceptInvitation $acceptInvitation */
+            $acceptInvitation = app(AcceptInvitation::class);
+            $acceptInvitation->handle($existingUser, $invitation);
+        }
+
         $this->emailInvitation($invitation);
 
         return $invitation;

--- a/resources/views/workspaces/emails/invitation-to-existing-user.blade.php
+++ b/resources/views/workspaces/emails/invitation-to-existing-user.blade.php
@@ -2,6 +2,6 @@
 
 <p>{{__(':userName has added you to their workspace on SendPortal!', ['userName' => $invitation->workspace->owner->name])}}</p>
 
-<p>{{__('Since you already have an account, you have automatically been added to the workspace, and do not need to take any further action.')}}</p>
+<p>{{__('Since you already have an account, you have automatically been added to the workspace.')}}</p>
 
 <p>{{__('See you soon!')}}</p>

--- a/resources/views/workspaces/emails/invitation-to-existing-user.blade.php
+++ b/resources/views/workspaces/emails/invitation-to-existing-user.blade.php
@@ -1,13 +1,7 @@
-{{__('Hi!')}}
+<p>{{__('Hi!')}}</p>
 
-<br><br>
+<p>{{__(':userName has added you to their workspace on SendPortal!', ['userName' => $invitation->workspace->owner->name])}}</p>
 
-{{__(':userName has invited you to join their workspace on SendPortal!', ['userName' => $invitation->workspace->owner->name])}}
+<p>{{__('Since you already have an account, you have automatically been added to the workspace, and do not need to take any further action.')}}</p>
 
-<br><br>
-
-{{__('Since you already have an account, you may accept the invitation from your account settings screen.')}}
-
-<br><br>
-
-{{__('See you soon!')}}
+<p>{{__('See you soon!')}}</p>

--- a/resources/views/workspaces/emails/invitation-to-new-user.blade.php
+++ b/resources/views/workspaces/emails/invitation-to-new-user.blade.php
@@ -1,14 +1,12 @@
-{{__('Hi!')}}
+<p>{{__('Hi!')}}</p>
 
-<br><br>
+<p>
+    {{__(':userName has invited you to join their workspace on SendPortal!', ['userName' => $invitation->workspace->owner->name])}}
+    {{__('If you do not already have an account, you may click the following link to get started:')}}
+</p>
 
-{{__(':userName has invited you to join their workspace on SendPortal!', ['userName' => $invitation->workspace->owner->name])}}
-{{__('If you do not already have an account, you may click the following link to get started:')}}
+<p>
+    <a href="{{ url('register?invitation='.$invitation->token) }}">{{ url('register?invitation='.$invitation->token) }}</a>
+</p>
 
-<br><br>
-
-<a href="{{ url('register?invitation='.$invitation->token) }}">{{ url('register?invitation='.$invitation->token) }}</a>
-
-<br><br>
-
-{{__('See you soon!')}}
+<p>{{__('See you soon!')}}</p>


### PR DESCRIPTION
This was prompted by Issue #126, where users who are only in the system
via an invitation, who subsequently get removed from the workspace they
were invited to, were unable to access the application at all to either
create their own workspace or accept an invitation to another existing
one.

By automatically accepting invitations that are made to existing users,
we avoid having to do things like deleting users if they have no
workspace, or adjusting the system so that it workspaceless users can
access workspace management features to create or accept invitations to
workspaces.

Additionally, this removes friction from adding users to new workspaces
in any given SendPortal instance. It seems unlikely that someone would
actually want to reject an invitation, given that it is a self-hosted
platform.

The ability to manually accept invitations has not been removed, as
there may be cases where invitations already exist that haven't yet
been handled.