### PR TITLE
ensuring 'workspace_id' is passed as int, during invite-processing

### DIFF
--- a/app/Services/Workspaces/AcceptInvitation.php
+++ b/app/Services/Workspaces/AcceptInvitation.php
@@ -31,7 +31,7 @@ class AcceptInvitation
      */
     public function handle(User $user, Invitation $invitation): bool
     {
-        $workspace = $this->resolveWorkspace($invitation->workspace_id);
+        $workspace = $this->resolveWorkspace(intval($invitation->workspace_id));
 
         if (!$workspace) {
             throw new RuntimeException("Invalid workspace ID encountered: {$invitation->workspace_id}");


### PR DESCRIPTION
Fixes mettle/sendportal#164

Prior to fix:
* registration process for a new user fails, with PHP Error noted in mettle/sendportal#164
* it appears the 'workspace_id' returned from database model is a valid workspace number, but not an integer

After fix:
* the 'workspace_id' is now converted to integer type, and passed to function which expects integer
* invitation processing works, new user can now register and proceed to 'email validation' stage